### PR TITLE
"Implement-n8n-webhook-services"

### DIFF
--- a/SmartSpend.API/Program.cs
+++ b/SmartSpend.API/Program.cs
@@ -1,9 +1,11 @@
 using System.Text;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using SmartSpend.Core.Interfaces;
 using SmartSpend.Core.Settings;
+using SmartSpend.Infrastructure.Auth;
 using SmartSpend.Infrastructure.Data;
 using SmartSpend.Infrastructure.Services;
 
@@ -35,12 +37,19 @@ builder.Services.AddAuthentication(options =>
         ValidAudience = jwtSettings.Audience,
         IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.SecretKey))
     };
-});
+})
+.AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>("ApiKey", null);
+
+// Configure API Key Settings
+builder.Services.Configure<ApiKeySettings>(builder.Configuration.GetSection("ApiKeySettings"));
 
 // Register services
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IExpenseService, ExpenseService>();
 builder.Services.AddScoped<ICategoryService, CategoryService>();
+builder.Services.AddScoped<IExpenseParsingService, ExpenseParsingService>();
+builder.Services.AddScoped<IExpenseSummaryService, ExpenseSummaryService>();
+builder.Services.AddScoped<IInsightService, InsightService>();
 
 // Add controllers
 builder.Services.AddControllers();

--- a/SmartSpend.API/appsettings.json
+++ b/SmartSpend.API/appsettings.json
@@ -14,5 +14,10 @@
     "Issuer": "SmartSpend",
     "Audience": "SmartSpend",
     "ExpirationInMinutes": 60
+  },
+  "ApiKeySettings": {
+    "ValidKeys": [
+      "n8n-webhook-key-change-me-in-production"
+    ]
   }
 }

--- a/SmartSpend.Core/DTOs/Webhooks/CreateInsightRequest.cs
+++ b/SmartSpend.Core/DTOs/Webhooks/CreateInsightRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SmartSpend.Core.DTOs.Webhooks;
+
+public class CreateInsightRequest
+{
+    [Required]
+    public int UserId { get; set; }
+
+    [Required]
+    [RegularExpression(@"^\d{4}-\d{2}$", ErrorMessage = "MonthYear must be in format 'YYYY-MM'")]
+    public string MonthYear { get; set; } = string.Empty;
+
+    [Required]
+    public string InsightText { get; set; } = string.Empty;
+}

--- a/SmartSpend.Core/DTOs/Webhooks/ExpenseSummaryResponse.cs
+++ b/SmartSpend.Core/DTOs/Webhooks/ExpenseSummaryResponse.cs
@@ -1,0 +1,11 @@
+namespace SmartSpend.Core.DTOs.Webhooks;
+
+public class ExpenseSummaryResponse
+{
+    public int UserId { get; set; }
+    public DateTime FromDate { get; set; }
+    public DateTime ToDate { get; set; }
+    public decimal TotalSpent { get; set; }
+    public Dictionary<string, decimal> CategoryBreakdown { get; set; } = new();
+    public int ExpenseCount { get; set; }
+}

--- a/SmartSpend.Core/DTOs/Webhooks/ParseExpenseRequest.cs
+++ b/SmartSpend.Core/DTOs/Webhooks/ParseExpenseRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SmartSpend.Core.DTOs.Webhooks;
+
+public class ParseExpenseRequest
+{
+    public string? RawText { get; set; }
+    public string? ImageUrl { get; set; }
+
+    [Required]
+    public int UserId { get; set; }
+}

--- a/SmartSpend.Core/DTOs/Webhooks/ParseExpenseResponse.cs
+++ b/SmartSpend.Core/DTOs/Webhooks/ParseExpenseResponse.cs
@@ -1,0 +1,11 @@
+namespace SmartSpend.Core.DTOs.Webhooks;
+
+public class ParseExpenseResponse
+{
+    public decimal Amount { get; set; }
+    public string Merchant { get; set; } = string.Empty;
+    public string CategoryName { get; set; } = string.Empty;
+    public DateTime ExpenseDate { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public double Confidence { get; set; }
+}

--- a/SmartSpend.Core/Interfaces/IExpenseParsingService.cs
+++ b/SmartSpend.Core/Interfaces/IExpenseParsingService.cs
@@ -1,0 +1,8 @@
+using SmartSpend.Core.DTOs.Webhooks;
+
+namespace SmartSpend.Core.Interfaces;
+
+public interface IExpenseParsingService
+{
+    Task<ParseExpenseResponse> ParseExpenseAsync(ParseExpenseRequest request);
+}

--- a/SmartSpend.Core/Interfaces/IExpenseSummaryService.cs
+++ b/SmartSpend.Core/Interfaces/IExpenseSummaryService.cs
@@ -1,0 +1,8 @@
+using SmartSpend.Core.DTOs.Webhooks;
+
+namespace SmartSpend.Core.Interfaces;
+
+public interface IExpenseSummaryService
+{
+    Task<ExpenseSummaryResponse> GetSummaryAsync(int userId, DateTime from, DateTime to);
+}

--- a/SmartSpend.Core/Interfaces/IInsightService.cs
+++ b/SmartSpend.Core/Interfaces/IInsightService.cs
@@ -1,0 +1,9 @@
+using SmartSpend.Core.DTOs.Webhooks;
+using SmartSpend.Core.Models;
+
+namespace SmartSpend.Core.Interfaces;
+
+public interface IInsightService
+{
+    Task<AIInsight> CreateInsightAsync(CreateInsightRequest request);
+}

--- a/SmartSpend.Core/Settings/ApiKeySettings.cs
+++ b/SmartSpend.Core/Settings/ApiKeySettings.cs
@@ -1,0 +1,6 @@
+namespace SmartSpend.Core.Settings;
+
+public class ApiKeySettings
+{
+    public List<string> ValidKeys { get; set; } = new();
+}

--- a/SmartSpend.Infrastructure/Auth/ApiKeyAuthenticationHandler.cs
+++ b/SmartSpend.Infrastructure/Auth/ApiKeyAuthenticationHandler.cs
@@ -1,0 +1,47 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SmartSpend.Core.Settings;
+
+namespace SmartSpend.Infrastructure.Auth;
+
+public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    private const string ApiKeyHeaderName = "X-API-Key";
+    private readonly ApiKeySettings _apiKeySettings;
+
+    public ApiKeyAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        IOptions<ApiKeySettings> apiKeySettings)
+        : base(options, logger, encoder)
+    {
+        _apiKeySettings = apiKeySettings.Value;
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(ApiKeyHeaderName, out var apiKeyValue))
+            return Task.FromResult(AuthenticateResult.Fail("API key is missing"));
+
+        var apiKey = apiKeyValue.ToString();
+
+        if (!_apiKeySettings.ValidKeys.Contains(apiKey))
+            return Task.FromResult(AuthenticateResult.Fail("Invalid API key"));
+
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, "n8n-webhook"),
+            new Claim(ClaimTypes.AuthenticationMethod, "ApiKey")
+        };
+
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/SmartSpend.Infrastructure/Services/ExpenseParsingService.cs
+++ b/SmartSpend.Infrastructure/Services/ExpenseParsingService.cs
@@ -1,0 +1,135 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using SmartSpend.Core.DTOs.Webhooks;
+using SmartSpend.Core.Interfaces;
+using SmartSpend.Infrastructure.Data;
+
+namespace SmartSpend.Infrastructure.Services;
+
+public class ExpenseParsingService : IExpenseParsingService
+{
+    private readonly AppDbContext _context;
+
+    private static readonly Dictionary<string, string[]> CategoryKeywords = new()
+    {
+        ["Food"] = ["lunch", "dinner", "breakfast", "coffee", "restaurant", "cafe", "pizza", "burger", "subway", "mcdonald", "starbucks", "eat", "food", "grocery", "groceries"],
+        ["Transport"] = ["uber", "lyft", "taxi", "cab", "gas", "fuel", "parking", "bus", "train", "metro", "ride", "transport", "drive"],
+        ["Shopping"] = ["amazon", "walmart", "target", "store", "shop", "buy", "purchase", "mall", "clothes", "clothing"],
+        ["Entertainment"] = ["movie", "netflix", "spotify", "game", "concert", "show", "theater", "theatre", "ticket", "entertainment"]
+    };
+
+    public ExpenseParsingService(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ParseExpenseResponse> ParseExpenseAsync(ParseExpenseRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.RawText))
+            throw new InvalidOperationException("RawText is required for expense parsing");
+
+        var text = request.RawText;
+        var amount = ExtractAmount(text);
+        var merchant = ExtractMerchant(text);
+        var date = ExtractDate(text);
+        var categoryName = await MapCategoryAsync(text, request.UserId);
+        var confidence = CalculateConfidence(amount, merchant, date);
+
+        return new ParseExpenseResponse
+        {
+            Amount = amount,
+            Merchant = merchant,
+            CategoryName = categoryName,
+            ExpenseDate = date,
+            Description = text,
+            Confidence = confidence
+        };
+    }
+
+    private static decimal ExtractAmount(string text)
+    {
+        // Match patterns like $25.50, $25, 25.50, etc.
+        var match = Regex.Match(text, @"\$(\d+(?:\.\d{1,2})?)");
+        if (match.Success && decimal.TryParse(match.Groups[1].Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var amount))
+            return amount;
+
+        // Try without dollar sign - look for standalone numbers
+        match = Regex.Match(text, @"(?:^|\s)(\d+(?:\.\d{1,2})?)(?:\s|$)");
+        if (match.Success && decimal.TryParse(match.Groups[1].Value, NumberStyles.Any, CultureInfo.InvariantCulture, out amount))
+            return amount;
+
+        throw new InvalidOperationException("Could not extract amount from text");
+    }
+
+    private static string ExtractMerchant(string text)
+    {
+        // Try "at <merchant>" pattern
+        var match = Regex.Match(text, @"\bat\s+([A-Z][A-Za-z'']+(?:\s+[A-Z][A-Za-z'']+)*)", RegexOptions.None);
+        if (match.Success)
+            return match.Groups[1].Value;
+
+        // Try "at <merchant>" with lowercase
+        match = Regex.Match(text, @"\bat\s+(\w+(?:'s)?)", RegexOptions.IgnoreCase);
+        if (match.Success)
+            return match.Groups[1].Value;
+
+        return string.Empty;
+    }
+
+    private static DateTime ExtractDate(string text)
+    {
+        // ISO format: 2026-03-15
+        var match = Regex.Match(text, @"(\d{4}-\d{2}-\d{2})");
+        if (match.Success && DateTime.TryParse(match.Groups[1].Value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+            return date;
+
+        // US format: 03/15/2026
+        match = Regex.Match(text, @"(\d{1,2}/\d{1,2}/\d{4})");
+        if (match.Success && DateTime.TryParse(match.Groups[1].Value, CultureInfo.InvariantCulture, DateTimeStyles.None, out date))
+            return date;
+
+        // "on March 15" etc.
+        match = Regex.Match(text, @"on\s+((?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2})", RegexOptions.IgnoreCase);
+        if (match.Success && DateTime.TryParse(match.Groups[1].Value, CultureInfo.InvariantCulture, DateTimeStyles.None, out date))
+            return date;
+
+        return DateTime.UtcNow.Date;
+    }
+
+    private async Task<string> MapCategoryAsync(string text, int userId)
+    {
+        var textLower = text.ToLowerInvariant();
+
+        // Check keyword matches
+        foreach (var (category, keywords) in CategoryKeywords)
+        {
+            if (keywords.Any(k => textLower.Contains(k)))
+            {
+                // Verify category exists in DB
+                var exists = await _context.Categories
+                    .AnyAsync(c => c.Name == category && (c.IsDefault || c.UserId == userId));
+                if (exists)
+                    return category;
+            }
+        }
+
+        // Default to "Other"
+        var otherExists = await _context.Categories
+            .AnyAsync(c => c.Name == "Other" && (c.IsDefault || c.UserId == userId));
+
+        return otherExists ? "Other" : "Other";
+    }
+
+    private static double CalculateConfidence(decimal amount, string merchant, DateTime date)
+    {
+        var confidence = 0.0;
+
+        if (amount > 0) confidence += 0.4;
+        if (!string.IsNullOrEmpty(merchant)) confidence += 0.3;
+        if (date != DateTime.UtcNow.Date) confidence += 0.2;
+        else confidence += 0.1; // Still some confidence even with default date
+
+        return Math.Min(confidence, 1.0);
+    }
+}

--- a/SmartSpend.Infrastructure/Services/ExpenseSummaryService.cs
+++ b/SmartSpend.Infrastructure/Services/ExpenseSummaryService.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSpend.Core.DTOs.Webhooks;
+using SmartSpend.Core.Interfaces;
+using SmartSpend.Infrastructure.Data;
+
+namespace SmartSpend.Infrastructure.Services;
+
+public class ExpenseSummaryService : IExpenseSummaryService
+{
+    private readonly AppDbContext _context;
+
+    public ExpenseSummaryService(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ExpenseSummaryResponse> GetSummaryAsync(int userId, DateTime from, DateTime to)
+    {
+        var expenses = await _context.Expenses
+            .Include(e => e.Category)
+            .Where(e => e.UserId == userId
+                && e.ExpenseDate >= from
+                && e.ExpenseDate <= to)
+            .ToListAsync();
+
+        var categoryBreakdown = expenses
+            .GroupBy(e => e.Category.Name)
+            .ToDictionary(g => g.Key, g => g.Sum(e => e.Amount));
+
+        return new ExpenseSummaryResponse
+        {
+            UserId = userId,
+            FromDate = from,
+            ToDate = to,
+            TotalSpent = expenses.Sum(e => e.Amount),
+            CategoryBreakdown = categoryBreakdown,
+            ExpenseCount = expenses.Count
+        };
+    }
+}

--- a/SmartSpend.Infrastructure/Services/InsightService.cs
+++ b/SmartSpend.Infrastructure/Services/InsightService.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSpend.Core.DTOs.Webhooks;
+using SmartSpend.Core.Interfaces;
+using SmartSpend.Core.Models;
+using SmartSpend.Infrastructure.Data;
+
+namespace SmartSpend.Infrastructure.Services;
+
+public class InsightService : IInsightService
+{
+    private readonly AppDbContext _context;
+
+    public InsightService(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<AIInsight> CreateInsightAsync(CreateInsightRequest request)
+    {
+        var userExists = await _context.Users.AnyAsync(u => u.Id == request.UserId);
+        if (!userExists)
+            throw new InvalidOperationException("User not found");
+
+        // Check for existing insight for same user and month (upsert)
+        var existing = await _context.AIInsights
+            .FirstOrDefaultAsync(i => i.UserId == request.UserId && i.MonthYear == request.MonthYear);
+
+        if (existing != null)
+        {
+            existing.InsightText = request.InsightText;
+            existing.GeneratedAt = DateTime.UtcNow;
+            existing.ExpiresAt = DateTime.UtcNow.AddDays(30);
+
+            await _context.SaveChangesAsync();
+            return existing;
+        }
+
+        var insight = new AIInsight
+        {
+            UserId = request.UserId,
+            MonthYear = request.MonthYear,
+            InsightText = request.InsightText,
+            GeneratedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddDays(30)
+        };
+
+        _context.AIInsights.Add(insight);
+        await _context.SaveChangesAsync();
+
+        return insight;
+    }
+}

--- a/SmartSpend.Infrastructure/SmartSpend.Infrastructure.csproj
+++ b/SmartSpend.Infrastructure/SmartSpend.Infrastructure.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">

--- a/SmartSpend.Tests/Services/ExpenseParsingServiceTests.cs
+++ b/SmartSpend.Tests/Services/ExpenseParsingServiceTests.cs
@@ -1,0 +1,194 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSpend.Core.DTOs.Webhooks;
+using SmartSpend.Core.Models;
+using SmartSpend.Infrastructure.Data;
+using SmartSpend.Infrastructure.Services;
+
+namespace SmartSpend.Tests.Services;
+
+public class ExpenseParsingServiceTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly ExpenseParsingService _service;
+    private readonly int _userId;
+
+    public ExpenseParsingServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new AppDbContext(options);
+
+        var user = new User
+        {
+            Email = "test@example.com",
+            PasswordHash = "hashed",
+            FullName = "Test User"
+        };
+        _context.Users.Add(user);
+
+        // Seed categories
+        _context.Categories.AddRange(
+            new Category { Name = "Food", Icon = "🍔", IsDefault = true },
+            new Category { Name = "Transport", Icon = "🚗", IsDefault = true },
+            new Category { Name = "Shopping", Icon = "🛒", IsDefault = true },
+            new Category { Name = "Entertainment", Icon = "🎬", IsDefault = true },
+            new Category { Name = "Other", Icon = "📦", IsDefault = true }
+        );
+        _context.SaveChanges();
+
+        _userId = user.Id;
+        _service = new ExpenseParsingService(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_SimpleAmountAndMerchant_ExtractsCorrectly()
+    {
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Spent $25.50 at McDonald's",
+            UserId = _userId
+        };
+
+        var result = await _service.ParseExpenseAsync(request);
+
+        result.Amount.Should().Be(25.50m);
+        result.Merchant.Should().Be("McDonald's");
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_WithDate_ExtractsDate()
+    {
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Paid $10 at Starbucks on 2026-03-15",
+            UserId = _userId
+        };
+
+        var result = await _service.ParseExpenseAsync(request);
+
+        result.Amount.Should().Be(10m);
+        result.ExpenseDate.Should().Be(new DateTime(2026, 3, 15));
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_NoDate_DefaultsToToday()
+    {
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Spent $5 at cafe",
+            UserId = _userId
+        };
+
+        var result = await _service.ParseExpenseAsync(request);
+
+        result.ExpenseDate.Date.Should().Be(DateTime.UtcNow.Date);
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_FoodKeyword_MapsFoodCategory()
+    {
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Lunch at Subway for $12",
+            UserId = _userId
+        };
+
+        var result = await _service.ParseExpenseAsync(request);
+
+        result.CategoryName.Should().Be("Food");
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_TransportKeyword_MapsTransportCategory()
+    {
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Uber ride $15",
+            UserId = _userId
+        };
+
+        var result = await _service.ParseExpenseAsync(request);
+
+        result.CategoryName.Should().Be("Transport");
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_NoMatchingCategory_DefaultsToOther()
+    {
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Paid $50 for random stuff",
+            UserId = _userId
+        };
+
+        var result = await _service.ParseExpenseAsync(request);
+
+        result.CategoryName.Should().Be("Other");
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_NoAmount_ThrowsException()
+    {
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Bought something at the store",
+            UserId = _userId
+        };
+
+        var act = async () => await _service.ParseExpenseAsync(request);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*amount*");
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_NullRawText_ThrowsException()
+    {
+        var request = new ParseExpenseRequest
+        {
+            RawText = null,
+            UserId = _userId
+        };
+
+        var act = async () => await _service.ParseExpenseAsync(request);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*RawText*");
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_SetsConfidenceScore()
+    {
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Spent $25.50 at McDonald's on 2026-03-15",
+            UserId = _userId
+        };
+
+        var result = await _service.ParseExpenseAsync(request);
+
+        result.Confidence.Should().BeGreaterThan(0).And.BeLessThanOrEqualTo(1.0);
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_SetsDescription()
+    {
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Spent $25.50 at McDonald's",
+            UserId = _userId
+        };
+
+        var result = await _service.ParseExpenseAsync(request);
+
+        result.Description.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/SmartSpend.Tests/Services/ExpenseSummaryServiceTests.cs
+++ b/SmartSpend.Tests/Services/ExpenseSummaryServiceTests.cs
@@ -1,0 +1,197 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSpend.Core.Models;
+using SmartSpend.Infrastructure.Data;
+using SmartSpend.Infrastructure.Services;
+
+namespace SmartSpend.Tests.Services;
+
+public class ExpenseSummaryServiceTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly ExpenseSummaryService _service;
+    private readonly int _userId;
+    private readonly int _categoryId1;
+    private readonly int _categoryId2;
+
+    public ExpenseSummaryServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new AppDbContext(options);
+
+        var user = new User
+        {
+            Email = "test@example.com",
+            PasswordHash = "hashed",
+            FullName = "Test User"
+        };
+        _context.Users.Add(user);
+
+        var cat1 = new Category { Name = "Food", Icon = "🍔", IsDefault = true };
+        var cat2 = new Category { Name = "Transport", Icon = "🚗", IsDefault = true };
+        _context.Categories.AddRange(cat1, cat2);
+        _context.SaveChanges();
+
+        _userId = user.Id;
+        _categoryId1 = cat1.Id;
+        _categoryId2 = cat2.Id;
+
+        _service = new ExpenseSummaryService(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithExpenses_ReturnsTotalSpent()
+    {
+        SeedExpenses();
+
+        var result = await _service.GetSummaryAsync(_userId,
+            new DateTime(2026, 3, 1), new DateTime(2026, 3, 31));
+
+        result.TotalSpent.Should().Be(60m); // 10 + 20 + 30
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithExpenses_ReturnsCorrectCount()
+    {
+        SeedExpenses();
+
+        var result = await _service.GetSummaryAsync(_userId,
+            new DateTime(2026, 3, 1), new DateTime(2026, 3, 31));
+
+        result.ExpenseCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithExpenses_ReturnsCategoryBreakdown()
+    {
+        SeedExpenses();
+
+        var result = await _service.GetSummaryAsync(_userId,
+            new DateTime(2026, 3, 1), new DateTime(2026, 3, 31));
+
+        result.CategoryBreakdown.Should().ContainKey("Food").WhoseValue.Should().Be(30m);
+        result.CategoryBreakdown.Should().ContainKey("Transport").WhoseValue.Should().Be(30m);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_SetsDateRange()
+    {
+        var from = new DateTime(2026, 3, 1);
+        var to = new DateTime(2026, 3, 31);
+
+        var result = await _service.GetSummaryAsync(_userId, from, to);
+
+        result.UserId.Should().Be(_userId);
+        result.FromDate.Should().Be(from);
+        result.ToDate.Should().Be(to);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_NoExpenses_ReturnsZeroTotals()
+    {
+        var result = await _service.GetSummaryAsync(_userId,
+            new DateTime(2026, 3, 1), new DateTime(2026, 3, 31));
+
+        result.TotalSpent.Should().Be(0);
+        result.ExpenseCount.Should().Be(0);
+        result.CategoryBreakdown.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_FiltersOutOfRangeExpenses()
+    {
+        SeedExpenses();
+
+        // Add an expense outside the range
+        _context.Expenses.Add(new Expense
+        {
+            UserId = _userId,
+            CategoryId = _categoryId1,
+            Amount = 100m,
+            ExpenseDate = new DateTime(2026, 4, 15),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        _context.SaveChanges();
+
+        var result = await _service.GetSummaryAsync(_userId,
+            new DateTime(2026, 3, 1), new DateTime(2026, 3, 31));
+
+        result.TotalSpent.Should().Be(60m);
+        result.ExpenseCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_OnlyReturnsUserExpenses()
+    {
+        SeedExpenses();
+
+        // Add expense for another user
+        var otherUser = new User
+        {
+            Email = "other@example.com",
+            PasswordHash = "hashed",
+            FullName = "Other User"
+        };
+        _context.Users.Add(otherUser);
+        _context.SaveChanges();
+
+        _context.Expenses.Add(new Expense
+        {
+            UserId = otherUser.Id,
+            CategoryId = _categoryId1,
+            Amount = 500m,
+            ExpenseDate = new DateTime(2026, 3, 10),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        _context.SaveChanges();
+
+        var result = await _service.GetSummaryAsync(_userId,
+            new DateTime(2026, 3, 1), new DateTime(2026, 3, 31));
+
+        result.TotalSpent.Should().Be(60m);
+    }
+
+    private void SeedExpenses()
+    {
+        _context.Expenses.AddRange(
+            new Expense
+            {
+                UserId = _userId,
+                CategoryId = _categoryId1,
+                Amount = 10m,
+                ExpenseDate = new DateTime(2026, 3, 5),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            },
+            new Expense
+            {
+                UserId = _userId,
+                CategoryId = _categoryId1,
+                Amount = 20m,
+                ExpenseDate = new DateTime(2026, 3, 10),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            },
+            new Expense
+            {
+                UserId = _userId,
+                CategoryId = _categoryId2,
+                Amount = 30m,
+                ExpenseDate = new DateTime(2026, 3, 15),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        );
+        _context.SaveChanges();
+    }
+}

--- a/SmartSpend.Tests/Services/InsightServiceTests.cs
+++ b/SmartSpend.Tests/Services/InsightServiceTests.cs
@@ -1,0 +1,174 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSpend.Core.DTOs.Webhooks;
+using SmartSpend.Core.Models;
+using SmartSpend.Infrastructure.Data;
+using SmartSpend.Infrastructure.Services;
+
+namespace SmartSpend.Tests.Services;
+
+public class InsightServiceTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly InsightService _service;
+    private readonly int _userId;
+
+    public InsightServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new AppDbContext(options);
+
+        var user = new User
+        {
+            Email = "test@example.com",
+            PasswordHash = "hashed",
+            FullName = "Test User"
+        };
+        _context.Users.Add(user);
+        _context.SaveChanges();
+
+        _userId = user.Id;
+        _service = new InsightService(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async Task CreateInsightAsync_ValidRequest_CreatesInsight()
+    {
+        var request = new CreateInsightRequest
+        {
+            UserId = _userId,
+            MonthYear = "2026-03",
+            InsightText = "You spent 30% more on food this month."
+        };
+
+        var result = await _service.CreateInsightAsync(request);
+
+        result.Should().NotBeNull();
+        result.Id.Should().BeGreaterThan(0);
+        result.UserId.Should().Be(_userId);
+        result.MonthYear.Should().Be("2026-03");
+        result.InsightText.Should().Be("You spent 30% more on food this month.");
+    }
+
+    [Fact]
+    public async Task CreateInsightAsync_SetsGeneratedAt()
+    {
+        var request = new CreateInsightRequest
+        {
+            UserId = _userId,
+            MonthYear = "2026-03",
+            InsightText = "Test insight"
+        };
+
+        var before = DateTime.UtcNow;
+        var result = await _service.CreateInsightAsync(request);
+        var after = DateTime.UtcNow;
+
+        result.GeneratedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    [Fact]
+    public async Task CreateInsightAsync_SetsExpiresAt30Days()
+    {
+        var request = new CreateInsightRequest
+        {
+            UserId = _userId,
+            MonthYear = "2026-03",
+            InsightText = "Test insight"
+        };
+
+        var result = await _service.CreateInsightAsync(request);
+
+        result.ExpiresAt.Should().NotBeNull();
+        result.ExpiresAt!.Value.Should().BeCloseTo(
+            result.GeneratedAt.AddDays(30), TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task CreateInsightAsync_PersistsToDatabase()
+    {
+        var request = new CreateInsightRequest
+        {
+            UserId = _userId,
+            MonthYear = "2026-03",
+            InsightText = "Persisted insight"
+        };
+
+        var result = await _service.CreateInsightAsync(request);
+
+        var saved = await _context.AIInsights.FindAsync(result.Id);
+        saved.Should().NotBeNull();
+        saved!.InsightText.Should().Be("Persisted insight");
+    }
+
+    [Fact]
+    public async Task CreateInsightAsync_InvalidUser_ThrowsException()
+    {
+        var request = new CreateInsightRequest
+        {
+            UserId = 999,
+            MonthYear = "2026-03",
+            InsightText = "Test"
+        };
+
+        var act = async () => await _service.CreateInsightAsync(request);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*User not found*");
+    }
+
+    [Fact]
+    public async Task CreateInsightAsync_ExistingMonthYear_UpdatesExisting()
+    {
+        var request1 = new CreateInsightRequest
+        {
+            UserId = _userId,
+            MonthYear = "2026-03",
+            InsightText = "Original insight"
+        };
+        await _service.CreateInsightAsync(request1);
+
+        var request2 = new CreateInsightRequest
+        {
+            UserId = _userId,
+            MonthYear = "2026-03",
+            InsightText = "Updated insight"
+        };
+        var result = await _service.CreateInsightAsync(request2);
+
+        result.InsightText.Should().Be("Updated insight");
+
+        var count = await _context.AIInsights
+            .CountAsync(i => i.UserId == _userId && i.MonthYear == "2026-03");
+        count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreateInsightAsync_DifferentMonthYear_CreatesSeparate()
+    {
+        await _service.CreateInsightAsync(new CreateInsightRequest
+        {
+            UserId = _userId,
+            MonthYear = "2026-02",
+            InsightText = "February insight"
+        });
+
+        await _service.CreateInsightAsync(new CreateInsightRequest
+        {
+            UserId = _userId,
+            MonthYear = "2026-03",
+            InsightText = "March insight"
+        });
+
+        var count = await _context.AIInsights.CountAsync(i => i.UserId == _userId);
+        count.Should().Be(2);
+    }
+}


### PR DESCRIPTION
## Summary
- Add webhook DTOs (ParseExpenseRequest/Response, ExpenseSummaryResponse, CreateInsightRequest) in Core
- Add service interfaces (IExpenseParsingService, IExpenseSummaryService, IInsightService) in Core
- Add ApiKeySettings configuration class in Core
- Implement ExpenseParsingService with regex-based text parsing for amounts, merchants, dates, and category mapping
- Implement ExpenseSummaryService with date range filtering and category breakdown
- Implement InsightService with upsert logic and 30-day expiry
- Add ApiKeyAuthenticationHandler for X-API-Key header validation
- Register all services and auth scheme in Program.cs DI
- 24 unit tests covering all three services (63 total pass)

## Test plan
- [x] All 63 tests pass: `dotnet test`
- [x] Build succeeds: `dotnet build`

Closes #14, closes #15
