### PR TITLE
"Add-webhook-controller-endpoints"

### DIFF
--- a/SmartSpend.API/Controllers/WebhooksController.cs
+++ b/SmartSpend.API/Controllers/WebhooksController.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SmartSpend.Core.DTOs.Webhooks;
+using SmartSpend.Core.Interfaces;
+
+namespace SmartSpend.API.Controllers;
+
+[ApiController]
+[Route("api/webhooks")]
+[Authorize(AuthenticationSchemes = "ApiKey")]
+public class WebhooksController : ControllerBase
+{
+    private readonly IExpenseParsingService _parsingService;
+    private readonly IExpenseSummaryService _summaryService;
+    private readonly IInsightService _insightService;
+
+    public WebhooksController(
+        IExpenseParsingService parsingService,
+        IExpenseSummaryService summaryService,
+        IInsightService insightService)
+    {
+        _parsingService = parsingService;
+        _summaryService = summaryService;
+        _insightService = insightService;
+    }
+
+    [HttpPost("expenses/parse")]
+    public async Task<ActionResult<ParseExpenseResponse>> ParseExpense([FromBody] ParseExpenseRequest request)
+    {
+        try
+        {
+            var result = await _parsingService.ParseExpenseAsync(request);
+            return Ok(result);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpGet("expenses/summary")]
+    public async Task<ActionResult<ExpenseSummaryResponse>> GetExpenseSummary(
+        [FromQuery] int userId,
+        [FromQuery] DateTime from,
+        [FromQuery] DateTime to)
+    {
+        var result = await _summaryService.GetSummaryAsync(userId, from, to);
+        return Ok(result);
+    }
+
+    [HttpPost("insights")]
+    public async Task<ActionResult> CreateInsight([FromBody] CreateInsightRequest request)
+    {
+        try
+        {
+            var result = await _insightService.CreateInsightAsync(request);
+            return CreatedAtAction(null, new { id = result.Id }, result);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add WebhooksController with 3 n8n webhook endpoints
- POST /api/webhooks/expenses/parse - parses raw text into structured expense data
- GET /api/webhooks/expenses/summary - returns spending summary with category breakdown
- POST /api/webhooks/insights - stores AI-generated monthly insights
- All endpoints secured with ApiKey authentication scheme
- Merges services-agent work (DTOs, interfaces, service implementations)

## Test plan
- [x] All 63 tests pass: `dotnet test`
- [x] Build succeeds: `dotnet build`

Closes #13
