### PR TITLE
"Add-webhook-integration-tests"

### DIFF
--- a/SmartSpend.API/Controllers/WebhooksController.cs
+++ b/SmartSpend.API/Controllers/WebhooksController.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SmartSpend.Core.DTOs.Webhooks;
+using SmartSpend.Core.Interfaces;
+
+namespace SmartSpend.API.Controllers;
+
+[ApiController]
+[Route("api/webhooks")]
+[Authorize(AuthenticationSchemes = "ApiKey")]
+public class WebhooksController : ControllerBase
+{
+    private readonly IExpenseParsingService _parsingService;
+    private readonly IExpenseSummaryService _summaryService;
+    private readonly IInsightService _insightService;
+
+    public WebhooksController(
+        IExpenseParsingService parsingService,
+        IExpenseSummaryService summaryService,
+        IInsightService insightService)
+    {
+        _parsingService = parsingService;
+        _summaryService = summaryService;
+        _insightService = insightService;
+    }
+
+    [HttpPost("expenses/parse")]
+    public async Task<ActionResult<ParseExpenseResponse>> ParseExpense([FromBody] ParseExpenseRequest request)
+    {
+        try
+        {
+            var result = await _parsingService.ParseExpenseAsync(request);
+            return Ok(result);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpGet("expenses/summary")]
+    public async Task<ActionResult<ExpenseSummaryResponse>> GetExpenseSummary(
+        [FromQuery] int userId,
+        [FromQuery] DateTime from,
+        [FromQuery] DateTime to)
+    {
+        var result = await _summaryService.GetSummaryAsync(userId, from, to);
+        return Ok(result);
+    }
+
+    [HttpPost("insights")]
+    public async Task<ActionResult> CreateInsight([FromBody] CreateInsightRequest request)
+    {
+        try
+        {
+            var result = await _insightService.CreateInsightAsync(request);
+            return CreatedAtAction(null, new { id = result.Id }, result);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+}

--- a/SmartSpend.Tests/Controllers/WebhooksControllerTests.cs
+++ b/SmartSpend.Tests/Controllers/WebhooksControllerTests.cs
@@ -1,0 +1,348 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SmartSpend.API.Controllers;
+using SmartSpend.Core.DTOs.Webhooks;
+using SmartSpend.Core.Interfaces;
+using SmartSpend.Core.Models;
+
+namespace SmartSpend.Tests.Controllers;
+
+public class WebhooksControllerTests
+{
+    private readonly Mock<IExpenseParsingService> _parsingServiceMock;
+    private readonly Mock<IExpenseSummaryService> _summaryServiceMock;
+    private readonly Mock<IInsightService> _insightServiceMock;
+    private readonly WebhooksController _controller;
+
+    public WebhooksControllerTests()
+    {
+        _parsingServiceMock = new Mock<IExpenseParsingService>();
+        _summaryServiceMock = new Mock<IExpenseSummaryService>();
+        _insightServiceMock = new Mock<IInsightService>();
+
+        _controller = new WebhooksController(
+            _parsingServiceMock.Object,
+            _summaryServiceMock.Object,
+            _insightServiceMock.Object);
+    }
+
+    #region Parse Endpoint Tests
+
+    [Fact]
+    public async Task ParseExpense_ValidRequest_ReturnsOkWithParsedExpense()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Spent $25 at McDonald's",
+            UserId = 1
+        };
+
+        var expected = new ParseExpenseResponse
+        {
+            Amount = 25m,
+            Merchant = "McDonald's",
+            CategoryName = "Food",
+            ExpenseDate = DateTime.UtcNow.Date,
+            Description = "Spent $25 at McDonald's",
+            Confidence = 0.8
+        };
+
+        _parsingServiceMock
+            .Setup(s => s.ParseExpenseAsync(request))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await _controller.ParseExpense(request);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<ParseExpenseResponse>().Subject;
+        response.Amount.Should().Be(25m);
+        response.Merchant.Should().Be("McDonald's");
+        response.CategoryName.Should().Be("Food");
+    }
+
+    [Fact]
+    public async Task ParseExpense_ServiceThrowsInvalidOperation_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "no amount here",
+            UserId = 1
+        };
+
+        _parsingServiceMock
+            .Setup(s => s.ParseExpenseAsync(request))
+            .ThrowsAsync(new InvalidOperationException("Could not extract amount from text"));
+
+        // Act
+        var result = await _controller.ParseExpense(request);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task ParseExpense_NullRawText_ServiceThrows_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = null,
+            UserId = 1
+        };
+
+        _parsingServiceMock
+            .Setup(s => s.ParseExpenseAsync(request))
+            .ThrowsAsync(new InvalidOperationException("RawText is required for expense parsing"));
+
+        // Act
+        var result = await _controller.ParseExpense(request);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task ParseExpense_CallsServiceWithCorrectRequest()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Test $10",
+            UserId = 42
+        };
+
+        _parsingServiceMock
+            .Setup(s => s.ParseExpenseAsync(It.IsAny<ParseExpenseRequest>()))
+            .ReturnsAsync(new ParseExpenseResponse { Amount = 10m });
+
+        // Act
+        await _controller.ParseExpense(request);
+
+        // Assert
+        _parsingServiceMock.Verify(
+            s => s.ParseExpenseAsync(It.Is<ParseExpenseRequest>(
+                r => r.RawText == "Test $10" && r.UserId == 42)),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region Summary Endpoint Tests
+
+    [Fact]
+    public async Task GetExpenseSummary_ValidRequest_ReturnsOkWithSummary()
+    {
+        // Arrange
+        var from = new DateTime(2026, 3, 1);
+        var to = new DateTime(2026, 3, 31);
+        var userId = 1;
+
+        var expected = new ExpenseSummaryResponse
+        {
+            UserId = userId,
+            FromDate = from,
+            ToDate = to,
+            TotalSpent = 150m,
+            ExpenseCount = 5,
+            CategoryBreakdown = new Dictionary<string, decimal>
+            {
+                ["Food"] = 100m,
+                ["Transport"] = 50m
+            }
+        };
+
+        _summaryServiceMock
+            .Setup(s => s.GetSummaryAsync(userId, from, to))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await _controller.GetExpenseSummary(userId, from, to);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<ExpenseSummaryResponse>().Subject;
+        response.TotalSpent.Should().Be(150m);
+        response.ExpenseCount.Should().Be(5);
+        response.CategoryBreakdown.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetExpenseSummary_NoExpenses_ReturnsOkWithZeroTotals()
+    {
+        // Arrange
+        var from = new DateTime(2026, 3, 1);
+        var to = new DateTime(2026, 3, 31);
+
+        _summaryServiceMock
+            .Setup(s => s.GetSummaryAsync(1, from, to))
+            .ReturnsAsync(new ExpenseSummaryResponse
+            {
+                UserId = 1,
+                FromDate = from,
+                ToDate = to,
+                TotalSpent = 0,
+                ExpenseCount = 0,
+                CategoryBreakdown = new()
+            });
+
+        // Act
+        var result = await _controller.GetExpenseSummary(1, from, to);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<ExpenseSummaryResponse>().Subject;
+        response.TotalSpent.Should().Be(0);
+        response.ExpenseCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetExpenseSummary_CallsServiceWithCorrectParameters()
+    {
+        // Arrange
+        var from = new DateTime(2026, 1, 1);
+        var to = new DateTime(2026, 1, 31);
+        var userId = 7;
+
+        _summaryServiceMock
+            .Setup(s => s.GetSummaryAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(new ExpenseSummaryResponse());
+
+        // Act
+        await _controller.GetExpenseSummary(userId, from, to);
+
+        // Assert
+        _summaryServiceMock.Verify(
+            s => s.GetSummaryAsync(7, from, to),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region Insight Endpoint Tests
+
+    [Fact]
+    public async Task CreateInsight_ValidRequest_ReturnsOkWithId()
+    {
+        // Arrange
+        var request = new CreateInsightRequest
+        {
+            UserId = 1,
+            MonthYear = "2026-03",
+            InsightText = "You spent 30% more on food this month."
+        };
+
+        _insightServiceMock
+            .Setup(s => s.CreateInsightAsync(request))
+            .ReturnsAsync(new AIInsight
+            {
+                Id = 42,
+                UserId = 1,
+                MonthYear = "2026-03",
+                InsightText = "You spent 30% more on food this month.",
+                GeneratedAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddDays(30)
+            });
+
+        // Act
+        var result = await _controller.CreateInsight(request);
+
+        // Assert
+        var createdResult = result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        createdResult.Value.Should().BeOfType<AIInsight>();
+        var insight = (AIInsight)createdResult.Value!;
+        insight.Id.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task CreateInsight_InvalidUser_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new CreateInsightRequest
+        {
+            UserId = 999,
+            MonthYear = "2026-03",
+            InsightText = "Test"
+        };
+
+        _insightServiceMock
+            .Setup(s => s.CreateInsightAsync(request))
+            .ThrowsAsync(new InvalidOperationException("User not found"));
+
+        // Act
+        var result = await _controller.CreateInsight(request);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task CreateInsight_CallsServiceWithCorrectRequest()
+    {
+        // Arrange
+        var request = new CreateInsightRequest
+        {
+            UserId = 5,
+            MonthYear = "2026-02",
+            InsightText = "Test insight text"
+        };
+
+        _insightServiceMock
+            .Setup(s => s.CreateInsightAsync(It.IsAny<CreateInsightRequest>()))
+            .ReturnsAsync(new AIInsight { Id = 1 });
+
+        // Act
+        await _controller.CreateInsight(request);
+
+        // Assert
+        _insightServiceMock.Verify(
+            s => s.CreateInsightAsync(It.Is<CreateInsightRequest>(
+                r => r.UserId == 5 && r.MonthYear == "2026-02" && r.InsightText == "Test insight text")),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region Controller Attribute Tests
+
+    [Fact]
+    public void WebhooksController_HasApiControllerAttribute()
+    {
+        // Assert
+        typeof(WebhooksController)
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Mvc.ApiControllerAttribute), true)
+            .Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void WebhooksController_HasAuthorizeAttribute_WithApiKeyScheme()
+    {
+        // Assert
+        var authorizeAttributes = typeof(WebhooksController)
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), true)
+            .Cast<Microsoft.AspNetCore.Authorization.AuthorizeAttribute>()
+            .ToList();
+
+        authorizeAttributes.Should().NotBeEmpty();
+        authorizeAttributes.Should().Contain(a => a.AuthenticationSchemes == "ApiKey");
+    }
+
+    [Fact]
+    public void WebhooksController_HasRouteAttribute()
+    {
+        // Assert
+        var routeAttributes = typeof(WebhooksController)
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Mvc.RouteAttribute), true)
+            .Cast<Microsoft.AspNetCore.Mvc.RouteAttribute>()
+            .ToList();
+
+        routeAttributes.Should().NotBeEmpty();
+        routeAttributes.Should().Contain(a => a.Template == "api/webhooks");
+    }
+
+    #endregion
+}

--- a/SmartSpend.Tests/Services/ApiKeyAuthHandlerTests.cs
+++ b/SmartSpend.Tests/Services/ApiKeyAuthHandlerTests.cs
@@ -1,0 +1,146 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using SmartSpend.Core.Settings;
+using SmartSpend.Infrastructure.Auth;
+
+namespace SmartSpend.Tests.Services;
+
+public class ApiKeyAuthHandlerTests
+{
+    private const string ValidApiKey = "test-api-key-123";
+    private const string SchemeName = "ApiKey";
+
+    private static async Task<AuthenticateResult> RunHandlerAsync(string? apiKeyHeader)
+    {
+        var apiKeySettings = new ApiKeySettings
+        {
+            ValidKeys = new List<string> { ValidApiKey }
+        };
+
+        var options = new Mock<IOptionsMonitor<AuthenticationSchemeOptions>>();
+        options.Setup(o => o.Get(SchemeName)).Returns(new AuthenticationSchemeOptions());
+
+        var loggerFactory = new Mock<ILoggerFactory>();
+        loggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>()))
+            .Returns(new Mock<ILogger>().Object);
+
+        var apiKeyOptions = new Mock<IOptions<ApiKeySettings>>();
+        apiKeyOptions.Setup(o => o.Value).Returns(apiKeySettings);
+
+        var handler = new ApiKeyAuthenticationHandler(
+            options.Object,
+            loggerFactory.Object,
+            UrlEncoder.Default,
+            apiKeyOptions.Object);
+
+        var scheme = new AuthenticationScheme(SchemeName, SchemeName, typeof(ApiKeyAuthenticationHandler));
+        var httpContext = new DefaultHttpContext();
+
+        if (apiKeyHeader != null)
+        {
+            httpContext.Request.Headers["X-API-Key"] = apiKeyHeader;
+        }
+
+        await handler.InitializeAsync(scheme, httpContext);
+
+        // Use reflection to call the protected HandleAuthenticateAsync
+        var method = typeof(ApiKeyAuthenticationHandler)
+            .GetMethod("HandleAuthenticateAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        var task = (Task<AuthenticateResult>)method!.Invoke(handler, null)!;
+        return await task;
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_ValidApiKey_ReturnsSuccess()
+    {
+        // Act
+        var result = await RunHandlerAsync(ValidApiKey);
+
+        // Assert
+        result.Succeeded.Should().BeTrue();
+        result.Principal.Should().NotBeNull();
+        result.Principal!.Identity!.IsAuthenticated.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_ValidApiKey_SetsExpectedClaims()
+    {
+        // Act
+        var result = await RunHandlerAsync(ValidApiKey);
+
+        // Assert
+        result.Succeeded.Should().BeTrue();
+        var nameClaim = result.Principal!.FindFirst(ClaimTypes.Name);
+        nameClaim.Should().NotBeNull();
+        nameClaim!.Value.Should().Be("n8n-webhook");
+
+        var authMethodClaim = result.Principal.FindFirst(ClaimTypes.AuthenticationMethod);
+        authMethodClaim.Should().NotBeNull();
+        authMethodClaim!.Value.Should().Be("ApiKey");
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_MissingApiKey_ReturnsFail()
+    {
+        // Act
+        var result = await RunHandlerAsync(null);
+
+        // Assert
+        result.Succeeded.Should().BeFalse();
+        result.Failure!.Message.Should().Contain("missing");
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_InvalidApiKey_ReturnsFail()
+    {
+        // Act
+        var result = await RunHandlerAsync("wrong-key");
+
+        // Assert
+        result.Succeeded.Should().BeFalse();
+        result.Failure!.Message.Should().Contain("Invalid");
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_EmptyApiKey_ReturnsFail()
+    {
+        // Act
+        var result = await RunHandlerAsync("");
+
+        // Assert
+        result.Succeeded.Should().BeFalse();
+        result.Failure!.Message.Should().Contain("Invalid");
+    }
+
+    [Theory]
+    [InlineData("test-api-key-123 ")] // trailing space
+    [InlineData(" test-api-key-123")] // leading space
+    [InlineData("TEST-API-KEY-123")] // wrong case
+    public async Task HandleAuthenticateAsync_SimilarButWrongKey_ReturnsFail(string apiKey)
+    {
+        // Act
+        var result = await RunHandlerAsync(apiKey);
+
+        // Assert
+        result.Succeeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_ValidKey_SetsSchemeNameOnTicket()
+    {
+        // Act
+        var result = await RunHandlerAsync(ValidApiKey);
+
+        // Assert
+        result.Succeeded.Should().BeTrue();
+        result.Ticket!.AuthenticationScheme.Should().Be(SchemeName);
+    }
+}

--- a/SmartSpend.Tests/Services/ExpenseParsingEdgeCaseTests.cs
+++ b/SmartSpend.Tests/Services/ExpenseParsingEdgeCaseTests.cs
@@ -1,0 +1,261 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSpend.Core.DTOs.Webhooks;
+using SmartSpend.Core.Models;
+using SmartSpend.Infrastructure.Data;
+using SmartSpend.Infrastructure.Services;
+
+namespace SmartSpend.Tests.Services;
+
+public class ExpenseParsingEdgeCaseTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly ExpenseParsingService _service;
+    private readonly int _userId;
+
+    public ExpenseParsingEdgeCaseTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new AppDbContext(options);
+
+        var user = new User
+        {
+            Email = "test@example.com",
+            PasswordHash = "hashed",
+            FullName = "Test User"
+        };
+        _context.Users.Add(user);
+
+        _context.Categories.AddRange(
+            new Category { Name = "Food", Icon = "F", IsDefault = true },
+            new Category { Name = "Transport", Icon = "T", IsDefault = true },
+            new Category { Name = "Shopping", Icon = "S", IsDefault = true },
+            new Category { Name = "Entertainment", Icon = "E", IsDefault = true },
+            new Category { Name = "Other", Icon = "O", IsDefault = true }
+        );
+        _context.SaveChanges();
+
+        _userId = user.Id;
+        _service = new ExpenseParsingService(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_EmptyString_ThrowsException()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "",
+            UserId = _userId
+        };
+
+        // Act
+        var act = async () => await _service.ParseExpenseAsync(request);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*RawText*");
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_WhitespaceOnly_ThrowsException()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "   ",
+            UserId = _userId
+        };
+
+        // Act
+        var act = async () => await _service.ParseExpenseAsync(request);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*RawText*");
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_LargeAmount_ExtractsCorrectly()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Paid $9999.99 at store",
+            UserId = _userId
+        };
+
+        // Act
+        var result = await _service.ParseExpenseAsync(request);
+
+        // Assert
+        result.Amount.Should().Be(9999.99m);
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_WholeNumberAmount_ExtractsCorrectly()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Spent $100 at the mall",
+            UserId = _userId
+        };
+
+        // Act
+        var result = await _service.ParseExpenseAsync(request);
+
+        // Assert
+        result.Amount.Should().Be(100m);
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_ShoppingKeyword_MapsShoppingCategory()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "$50 at Amazon store",
+            UserId = _userId
+        };
+
+        // Act
+        var result = await _service.ParseExpenseAsync(request);
+
+        // Assert
+        result.CategoryName.Should().Be("Shopping");
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_EntertainmentKeyword_MapsEntertainmentCategory()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Movie ticket $15",
+            UserId = _userId
+        };
+
+        // Act
+        var result = await _service.ParseExpenseAsync(request);
+
+        // Assert
+        result.CategoryName.Should().Be("Entertainment");
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_USDateFormat_ExtractsDate()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Paid $10 on 03/15/2026",
+            UserId = _userId
+        };
+
+        // Act
+        var result = await _service.ParseExpenseAsync(request);
+
+        // Assert
+        result.ExpenseDate.Should().Be(new DateTime(2026, 3, 15));
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_MultipleAmounts_ExtractsFirst()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Paid $10 and $20 at store",
+            UserId = _userId
+        };
+
+        // Act
+        var result = await _service.ParseExpenseAsync(request);
+
+        // Assert
+        result.Amount.Should().Be(10m);
+    }
+
+    [Theory]
+    [InlineData("Bought grocery items $45", "Food")]
+    [InlineData("Gas station $30", "Transport")]
+    [InlineData("Netflix subscription $15", "Entertainment")]
+    [InlineData("Walmart purchase $60", "Shopping")]
+    public async Task ParseExpenseAsync_VariousKeywords_MapsCorrectCategory(string rawText, string expectedCategory)
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = rawText,
+            UserId = _userId
+        };
+
+        // Act
+        var result = await _service.ParseExpenseAsync(request);
+
+        // Assert
+        result.CategoryName.Should().Be(expectedCategory);
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_HighConfidence_WhenAllFieldsPresent()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "Spent $25.50 at McDonald's on 2026-03-15",
+            UserId = _userId
+        };
+
+        // Act
+        var result = await _service.ParseExpenseAsync(request);
+
+        // Assert
+        result.Confidence.Should().BeGreaterThanOrEqualTo(0.7);
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_LowerConfidence_WhenNoMerchant()
+    {
+        // Arrange
+        var request = new ParseExpenseRequest
+        {
+            RawText = "$5 for something",
+            UserId = _userId
+        };
+
+        // Act
+        var result = await _service.ParseExpenseAsync(request);
+
+        // Assert
+        // No merchant extracted -> lower confidence
+        result.Confidence.Should().BeLessThan(0.9);
+    }
+
+    [Fact]
+    public async Task ParseExpenseAsync_DescriptionIsRawText()
+    {
+        // Arrange
+        var rawText = "Spent $25.50 at McDonald's";
+        var request = new ParseExpenseRequest
+        {
+            RawText = rawText,
+            UserId = _userId
+        };
+
+        // Act
+        var result = await _service.ParseExpenseAsync(request);
+
+        // Assert
+        result.Description.Should().Be(rawText);
+    }
+}


### PR DESCRIPTION
## Summary
- Add ApiKeyAuthHandlerTests (7 tests) - validates API key auth handler behavior
- Add WebhooksControllerTests (13 tests) - unit tests for all 3 webhook endpoints with mocked services
- Add ExpenseParsingEdgeCaseTests (12 tests) - edge cases for expense text parsing
- Merges services-agent and backend-agent work
- Total: 100 tests passing

## Test plan
- [x] All 100 tests pass: `dotnet test`
- [x] Build succeeds: `dotnet build`

Closes #16
